### PR TITLE
Change cookie policy to `BROWSER_COMPATIBILITY`

### DIFF
--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/HttpRetriever.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/HttpRetriever.java
@@ -184,7 +184,7 @@ public class HttpRetriever {
         setNumRetries(DEFAULT_NUM_RETRIES);
         setUserAgent(USER_AGENT);
         // https://bitbucket.org/palladian/palladian/issue/286/possibility-to-accept-cookies-in
-        httpParams.setParameter(ClientPNames.COOKIE_POLICY, CookiePolicy.BEST_MATCH);
+        httpParams.setParameter(ClientPNames.COOKIE_POLICY, CookiePolicy.BROWSER_COMPATIBILITY);
     }
 
     // ////////////////////////////////////////////////////////////////

--- a/palladian-retrieval/src/test/java/ws/palladian/retrieval/HttpRetrieverHttpBinTest.java
+++ b/palladian-retrieval/src/test/java/ws/palladian/retrieval/HttpRetrieverHttpBinTest.java
@@ -1,0 +1,43 @@
+package ws.palladian.retrieval;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import ws.palladian.helper.UrlHelper;
+
+/**
+ * Test for HTTP Retriever running against httpbin.org
+ * 
+ * @author Philipp Katz
+ */
+public class HttpRetrieverHttpBinTest {
+
+	/**
+	 * Test for “Invalid cookie header”, “Invalid 'expires' attribute”.
+	 * 
+	 * See here:
+	 * 
+	 * https://gitlab.com/palladian/palladian-knime/-/issues/57
+	 * https://forum.knime.com/t/using-cookie-retrieved-with-http-retriever-node-doesnt-work-in-workflow-however-copy-pasting-exact-same-cookie-from-web-console-does/27646
+	 * https://issues.apache.org/jira/browse/HTTPCLIENT-1763
+	 */
+	@Test
+	public void testCookiesExpiresDate() throws HttpException {
+		String cookieValue = "foo=bar; Expires=Mon, 05 Oct 2021 01:48:58 GMT";
+		HttpRequest2 request = new HttpRequest2Builder(HttpMethod.GET,
+				"https://httpbin.org/response-headers?set-cookie=" + UrlHelper.encodeParameter(cookieValue)).create();
+		HttpRetriever httpRetriever = HttpRetrieverFactory.getHttpRetriever();
+		CookieStore cookieStore = new DefaultCookieStore();
+		httpRetriever.setCookieStore(cookieStore);
+		HttpResult result = httpRetriever.execute(request);
+		assertEquals(200, result.getStatusCode());
+		assertEquals(1, cookieStore.getCookies().size());
+		Cookie cookie = cookieStore.getCookies().iterator().next();
+		assertEquals("foo", cookie.getName());
+		assertEquals("bar", cookie.getValue());
+		assertEquals("httpbin.org", cookie.getDomain());
+		assertEquals("/", cookie.getPath());
+	}
+
+}


### PR DESCRIPTION
* hope this will allow parsing more cookie headers
* see #57 in palladian-knime: https://gitlab.com/palladian/palladian-knime/-/issues/57
* see KNIME forum thread: https://forum.knime.com/t/using-cookie-retrieved-with-http-retriever-node-doesnt-work-in-workflow-however-copy-pasting-exact-same-cookie-from-web-console-does/27646
* https://issues.apache.org/jira/browse/HTTPCLIENT-1763