### PR TITLE
Snowball is also in Lucene -- so take this

### DIFF
--- a/palladian-core/pom.xml
+++ b/palladian-core/pom.xml
@@ -97,11 +97,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.rholder</groupId>
-            <artifactId>snowball-stemmer</artifactId>
-            <version>1.3.0.581.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.sun.media</groupId>
             <artifactId>jai-codec</artifactId>
             <version>1.1.3</version>

--- a/palladian-core/src/main/java/ws/palladian/extraction/feature/Stemmer.java
+++ b/palladian-core/src/main/java/ws/palladian/extraction/feature/Stemmer.java
@@ -1,22 +1,22 @@
 package ws.palladian.extraction.feature;
 
 import org.apache.commons.lang3.Validate;
-import org.tartarus.snowball.SnowballStemmer;
-import org.tartarus.snowball.ext.danishStemmer;
-import org.tartarus.snowball.ext.dutchStemmer;
-import org.tartarus.snowball.ext.englishStemmer;
-import org.tartarus.snowball.ext.finnishStemmer;
-import org.tartarus.snowball.ext.frenchStemmer;
-import org.tartarus.snowball.ext.germanStemmer;
-import org.tartarus.snowball.ext.hungarianStemmer;
-import org.tartarus.snowball.ext.italianStemmer;
-import org.tartarus.snowball.ext.norwegianStemmer;
-import org.tartarus.snowball.ext.portugueseStemmer;
-import org.tartarus.snowball.ext.romanianStemmer;
-import org.tartarus.snowball.ext.russianStemmer;
-import org.tartarus.snowball.ext.spanishStemmer;
-import org.tartarus.snowball.ext.swedishStemmer;
-import org.tartarus.snowball.ext.turkishStemmer;
+import org.tartarus.snowball.SnowballProgram;
+import org.tartarus.snowball.ext.DanishStemmer;
+import org.tartarus.snowball.ext.DutchStemmer;
+import org.tartarus.snowball.ext.EnglishStemmer;
+import org.tartarus.snowball.ext.FinnishStemmer;
+import org.tartarus.snowball.ext.FrenchStemmer;
+import org.tartarus.snowball.ext.GermanStemmer;
+import org.tartarus.snowball.ext.HungarianStemmer;
+import org.tartarus.snowball.ext.ItalianStemmer;
+import org.tartarus.snowball.ext.NorwegianStemmer;
+import org.tartarus.snowball.ext.PortugueseStemmer;
+import org.tartarus.snowball.ext.RomanianStemmer;
+import org.tartarus.snowball.ext.RussianStemmer;
+import org.tartarus.snowball.ext.SpanishStemmer;
+import org.tartarus.snowball.ext.SwedishStemmer;
+import org.tartarus.snowball.ext.TurkishStemmer;
 
 import ws.palladian.helper.constants.Language;
 import java.util.function.Function;
@@ -27,7 +27,7 @@ import java.util.function.Function;
  * @author Philipp Katz
  */
 public final class Stemmer implements Function<String, String> {
-    private final SnowballStemmer stemmer;
+    private final SnowballProgram stemmer;
 
     /**
      * <p>
@@ -43,44 +43,44 @@ public final class Stemmer implements Function<String, String> {
 
     /**
      * <p>
-     * Create a new {@link SnowballStemmer} for the specified {@link Language}.
+     * Create a new Snowball stemmer for the specified {@link Language}.
      * </p>
      * 
      * @param language
      * @return
      */
-    private static SnowballStemmer createStemmer(Language language) {
+    private static SnowballProgram createStemmer(Language language) {
         switch (language) {
             case DANISH:
-                return new danishStemmer();
+                return new DanishStemmer();
             case DUTCH:
-                return new dutchStemmer();
+                return new DutchStemmer();
             case ENGLISH:
-                return new englishStemmer();
+                return new EnglishStemmer();
             case FINNISH:
-                return new finnishStemmer();
+                return new FinnishStemmer();
             case FRENCH:
-                return new frenchStemmer();
+                return new FrenchStemmer();
             case GERMAN:
-                return new germanStemmer();
+                return new GermanStemmer();
             case HUNGARIAN:
-                return new hungarianStemmer();
+                return new HungarianStemmer();
             case ITALIAN:
-                return new italianStemmer();
+                return new ItalianStemmer();
             case NORWEGIAN:
-                return new norwegianStemmer();
+                return new NorwegianStemmer();
             case PORTUGUESE:
-                return new portugueseStemmer();
+                return new PortugueseStemmer();
             case ROMANIAN:
-                return new romanianStemmer();
+                return new RomanianStemmer();
             case RUSSIAN:
-                return new russianStemmer();
+                return new RussianStemmer();
             case SPANISH:
-                return new spanishStemmer();
+                return new SpanishStemmer();
             case SWEDISH:
-                return new swedishStemmer();
+                return new SwedishStemmer();
             case TURKISH:
-                return new turkishStemmer();
+                return new TurkishStemmer();
             default:
                 throw new IllegalArgumentException("No stemmer for language '" + language.toString() + "' available.");
         }

--- a/palladian-core/src/test/java/ws/palladian/extraction/feature/StemmerTest.java
+++ b/palladian-core/src/test/java/ws/palladian/extraction/feature/StemmerTest.java
@@ -15,4 +15,12 @@ public class StemmerTest {
         assertEquals("walk", stemmer.stem("walking"));
     }
 
+    @Test
+    public void testStemmerGerman() {
+        Stemmer stemmer = new Stemmer(Language.GERMAN);
+        assertEquals("geh", stemmer.stem("gehen"));
+        assertEquals("gegang", stemmer.stem("gegangen"));
+        assertEquals("gehend", stemmer.stem("gehend"));
+    }
+
 }


### PR DESCRIPTION
@ddsky reported this:

```
Exception in thread "Thread-4" java.lang.NoSuchMethodError: 'void org.tartarus.snowball.Among.<init>(java.lang.String, int, int, java.lang.String, org.tartarus.snowball.SnowballProgram)'
	at org.tartarus.snowball.ext.germanStemmer.<clinit>(germanStemmer.java:18)
	at ws.palladian.extraction.feature.Stemmer.createStemmer(Stemmer.java:65)
	at ws.palladian.extraction.feature.Stemmer.<init>(Stemmer.java:41)
	at ws.palladian.semantics.WordTransformer.stemGermanWord(WordTransformer.java:570)
	at ws.palladian.semantics.WordTransformer.stemWords(WordTransformer.java:541)
```

Removed dedicated Snowball lib, as it's provided by Lucene already. (added by me recently).