### PR TITLE
Sitemap fixes

### DIFF
--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/analysis/SitemapRetriever.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/analysis/SitemapRetriever.java
@@ -21,6 +21,8 @@ import ws.palladian.retrieval.HttpRetriever;
 import ws.palladian.retrieval.HttpRetrieverFactory;
 import ws.palladian.retrieval.parser.ParserFactory;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -97,7 +99,12 @@ public class SitemapRetriever {
 
         // is the sitemap gzipped?
         if (FileHelper.getFileType(sitemapUrl).equalsIgnoreCase("gz")) {
-            String tempPath = "data/temp/sitemapIndex-" + System.currentTimeMillis() + "-" + ((int) (Math.random() * 10000)) + ".xml";
+            String tempPath;
+            try {
+                tempPath = Files.createTempFile("sitemap-", ".xml").toString();
+            } catch (IOException e) {
+                throw new IllegalStateException("Could not create temporary file", e);
+            }
             documentRetriever.getHttpRetriever().downloadAndSave(sitemapUrl, tempPath + ".gzipped",
                     Optional.ofNullable(documentRetriever.getGlobalHeaders()).orElse(new HashMap<>()), false);
             FileHelper.ungzipFile(tempPath + ".gzipped", tempPath);

--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/analysis/SitemapRetriever.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/analysis/SitemapRetriever.java
@@ -376,7 +376,7 @@ public class SitemapRetriever {
         return Arrays.stream(robotsTxt.split("\n")) //
                 .filter(line -> line.startsWith(ROBOTS_TXT_SITEMAP_PREFIX)) //
                 .map(line -> line.replace(ROBOTS_TXT_SITEMAP_PREFIX, "").trim()) //
-                .toList();
+                .collect(Collectors.toList());
     }
 
     public static void main(String[] args) {

--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/analysis/SitemapRetriever.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/analysis/SitemapRetriever.java
@@ -4,6 +4,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import ws.palladian.helper.ProgressMonitor;
 import ws.palladian.helper.ProgressReporter;
+import ws.palladian.helper.UrlHelper;
 import ws.palladian.helper.collection.MapBuilder;
 import ws.palladian.helper.date.DateParser;
 import ws.palladian.helper.date.ExtractedDate;
@@ -38,6 +39,7 @@ public class SitemapRetriever {
     private final static Pattern PRIORITY_PATTERN = Pattern.compile("(?<=>)[0-9.]+?(?=</priority)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     private final static Pattern LAST_MOD_PATTERN = Pattern.compile("(?<=>)[^>]+?(?=</lastmod)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     public final static Pattern ALL = Pattern.compile(".");
+    private static final String ROBOTS_TXT_SITEMAP_PREFIX = "Sitemap:";
 
     public SitemapRetriever() {
         HttpRetriever httpRetriever = new HttpRetrieverFactory(true).create();
@@ -376,4 +378,20 @@ public class SitemapRetriever {
     public void setParseXml(boolean parseXml) {
         this.parseXml = parseXml;
     }
+
+    /**
+     * Try to find sitemaps via robots.txt in a given a URL.
+     * 
+     * @param url The URL.
+     * @return The discovered sitemaps, or an empty list.
+     */
+    public List<String> findSitemaps(String url) {
+        var domain = UrlHelper.getDomain(url, true);
+        var robotsTxt = documentRetriever.getText(domain + "/robots.txt");
+        return Arrays.stream(robotsTxt.split("\n")) //
+                .filter(line -> line.startsWith(ROBOTS_TXT_SITEMAP_PREFIX)) //
+                .map(line -> line.replace(ROBOTS_TXT_SITEMAP_PREFIX, "").trim()) //
+                .toList();
+    }
+
 }

--- a/palladian-retrieval/src/test/java/ws/palladian/retrieval/analysis/SitemapRetrieverTest.java
+++ b/palladian-retrieval/src/test/java/ws/palladian/retrieval/analysis/SitemapRetrieverTest.java
@@ -1,0 +1,29 @@
+package ws.palladian.retrieval.analysis;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+public class SitemapRetrieverTest {
+
+    @Test
+    public void testFindSitemap() {
+        SitemapRetriever sitemapRetriever = new SitemapRetriever();
+        assertEquals(Arrays.asList("http://www.atlasobscura.com/sitemaps/sitemap_index.xml.gz"),
+                sitemapRetriever.findSitemaps("https://www.atlasobscura.com"));
+
+        assertEquals(Arrays.asList( //
+                "https://www.apple.com/shop/sitemap.xml", //
+                "https://www.apple.com/autopush/sitemap/sitemap-index.xml", //
+                "https://www.apple.com/newsroom/sitemap.xml", //
+                "https://www.apple.com/retail/sitemap/sitemap.xml", //
+                "https://www.apple.com/today/sitemap.xml" //
+        ), sitemapRetriever.findSitemaps("https://apple.com"));
+
+        assertEquals(Collections.emptyList(), sitemapRetriever.findSitemaps("http://wikipedia.de"));
+    }
+
+}


### PR DESCRIPTION
The current version of the sitemap retriever does not handle deeply nested sitemap structures (ie. sitemaps with `sitemapindex` linking to another `sitemapindex` …). 

Example `https://www.apple.com/shop/sitemap.xml`:

* Current version of `getSitemap` gives `499` sitemap entries, which are all no HTML files, but XML files
* The modified version in this branch which handles nested structures returns `259,222` results

Can you check if this works for you, especially in regards to your existing crawlers?

Additional minor changes in this branch:

* discovery method for sitemaps based on robots file
* store temporary files in OS temp location