### PR TITLE
"psi" should not get translated to hpi cause PS is in a word

### DIFF
--- a/palladian-commons/src/main/java/ws/palladian/helper/normalization/UnitTranslator.java
+++ b/palladian-commons/src/main/java/ws/palladian/helper/normalization/UnitTranslator.java
@@ -2,11 +2,14 @@ package ws.palladian.helper.normalization;
 
 import ws.palladian.helper.collection.StringLengthComparator;
 import ws.palladian.helper.constants.Language;
+import ws.palladian.helper.nlp.PatternHelper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Created by David on 30.01.2018.
@@ -211,8 +214,10 @@ public class UnitTranslator {
         }
         inputString = inputString.toLowerCase();
         for (String key : keys) {
-            if (inputString.contains(key.toLowerCase())) {
-                inputString = inputString.replace(key.toLowerCase(), unitTranslations.get(language).get(key));
+            Pattern pattern = PatternHelper.compileOrGet("(?<=[\\d^\\s])(" + key.toLowerCase() + ")(?=($|\\s|[^A-Za-z0-9]))");
+            Matcher matcher = pattern.matcher(inputString);
+            if(matcher.find()) {
+                inputString = matcher.replaceFirst(unitTranslations.get(language).get(key));
                 break;
             }
         }

--- a/palladian-commons/src/test/java/ws/palladian/helper/normalization/UnitNormalizerTest.java
+++ b/palladian-commons/src/test/java/ws/palladian/helper/normalization/UnitNormalizerTest.java
@@ -84,6 +84,8 @@ public class UnitNormalizerTest {
         collector.checkThat(UnitNormalizer.getNormalizedNumber(5, UnitTranslator.translate("Zoll", Language.GERMAN)), Matchers.is(12.7));
         collector.checkThat(UnitNormalizer.getNormalizedNumber(1, UnitTranslator.translate("kilowattstunde", Language.GERMAN)), Matchers.is(3600000.));
 
+        collector.checkThat(UnitTranslator.translateUnitsOfInput("psi 30", Language.GERMAN), Matchers.is("psi 30"));
+        collector.checkThat(UnitTranslator.translateUnitsOfInput("PS5 neu gekauft!11!!", Language.GERMAN), Matchers.is("ps5 neu gekauft!11!!"));
         collector.checkThat(UnitTranslator.translateUnitsOfInput("schleuderdrehzahl 7 U/min", Language.GERMAN), Matchers.is("schleuderdrehzahl 7 rpm"));
         collector.checkThat(UnitTranslator.translateUnitsOfInput("schleuderdrehzahl 7 u/minute", Language.GERMAN), Matchers.is("schleuderdrehzahl 7 rpm"));
         collector.checkThat(


### PR DESCRIPTION
The Problem is that currently a normal contains get used in order to replace unit names.
This leads to unexpected results like "PS5 gekauft" -> "HP5" gekauft or "30 PSI" -> "30 HPI"  