### PR TITLE
Use Jsoup as default HTML parser

### DIFF
--- a/palladian-commons/src/main/java/ws/palladian/helper/html/HtmlHelper.java
+++ b/palladian-commons/src/main/java/ws/palladian/helper/html/HtmlHelper.java
@@ -59,6 +59,7 @@ public final class HtmlHelper {
     private static final Pattern HTML_TO_READABLE_TEXT = Pattern.compile("<(br|li)\\s?/?>", Pattern.CASE_INSENSITIVE);
     private static final Pattern HTML_TO_READABLE_TEXT2 = Pattern.compile("</p>", Pattern.CASE_INSENSITIVE);
     private static final Pattern NORMALIZE_LINES = Pattern.compile("^\\s+$|^[ \t]+|[ \t]+$", Pattern.MULTILINE);
+    private static final Pattern NORMALIZE_LINE_BREAKS = Pattern.compile("\r\n");
     private static final Pattern STRIP_ALL_TAGS = Pattern
             // .compile("<!--.*?-->|<script.*?>.*?</script>|<style.*?>.*?</style>|<.*?>", Pattern.DOTALL
             .compile("<!--.*?-->|<script.*?>.*?</script>|<style.*?>.*?</style>|<[^<]*?>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
@@ -365,6 +366,7 @@ public final class HtmlHelper {
 
         // result = result.replaceAll("[ \t]*?\n", "\n");
         result = NORMALIZE_LINES.matcher(result).replaceAll("");
+        result = NORMALIZE_LINE_BREAKS.matcher(result).replaceAll("\n");
         result = result.replaceAll("\n{3,}", "\n\n");
         result = result.replaceAll(" {2,}", " ");
 

--- a/palladian-commons/src/main/java/ws/palladian/helper/html/HtmlHelper.java
+++ b/palladian-commons/src/main/java/ws/palladian/helper/html/HtmlHelper.java
@@ -59,7 +59,7 @@ public final class HtmlHelper {
     private static final Pattern HTML_TO_READABLE_TEXT = Pattern.compile("<(br|li)\\s?/?>", Pattern.CASE_INSENSITIVE);
     private static final Pattern HTML_TO_READABLE_TEXT2 = Pattern.compile("</p>", Pattern.CASE_INSENSITIVE);
     private static final Pattern NORMALIZE_LINES = Pattern.compile("^\\s+$|^[ \t]+|[ \t]+$", Pattern.MULTILINE);
-    private static final Pattern NORMALIZE_LINE_BREAKS = Pattern.compile("\r\n");
+    public static final Pattern NORMALIZE_LINE_BREAKS = Pattern.compile("\r\n");
     private static final Pattern STRIP_ALL_TAGS = Pattern
             // .compile("<!--.*?-->|<script.*?>.*?</script>|<style.*?>.*?</style>|<.*?>", Pattern.DOTALL
             .compile("<!--.*?-->|<script.*?>.*?</script>|<style.*?>.*?</style>|<[^<]*?>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);

--- a/palladian-commons/src/main/java/ws/palladian/helper/html/XPathHelper.java
+++ b/palladian-commons/src/main/java/ws/palladian/helper/html/XPathHelper.java
@@ -444,6 +444,12 @@ public final class XPathHelper {
             return true;
         }
 
+        // no namespace is added by Jsoup parser parser on the first child
+        Node nextSibling = document.getFirstChild().getNextSibling();
+        if (nextSibling != null && nextSibling.getNodeName().equalsIgnoreCase("html") && XHTML_NAMESPACE.equals(nextSibling.getNamespaceURI())) {
+            return true;
+        }
+
         boolean result = false;
         Node node = null;
         if (document.getLastChild() != null && document.getLastChild().getAttributes() != null) {

--- a/palladian-commons/src/main/java/ws/palladian/helper/html/XPathHelper.java
+++ b/palladian-commons/src/main/java/ws/palladian/helper/html/XPathHelper.java
@@ -429,7 +429,7 @@ public final class XPathHelper {
             return true;
         }
 
-        // no namespace is added by Jsoup parser parser on the first child
+        // no namespace is added by Jsoup parser on the first child
         Node nextSibling = document.getFirstChild().getNextSibling();
         if (nextSibling != null && nextSibling.getNodeName().equalsIgnoreCase("html") && XHTML_NAMESPACE.equals(nextSibling.getNamespaceURI())) {
             return true;

--- a/palladian-commons/src/main/java/ws/palladian/helper/io/FileHelper.java
+++ b/palladian-commons/src/main/java/ws/palladian/helper/io/FileHelper.java
@@ -65,7 +65,7 @@ public final class FileHelper {
     /**
      * Constant for video file extensions.
      */
-    public static final List<String> VIDEO_FILE_EXTENSIONS = Arrays.asList("mp4", "flv", "avi", "mpeg2", "divx", "mov", "xvid", "wmv", "mpeg");
+    public static final List<String> VIDEO_FILE_EXTENSIONS = Arrays.asList("mp4", "flv", "avi", "mpeg2", "divx", "mov", "xvid", "wmv", "mpeg", "mpg", "m4v");
 
     /**
      * Constant for audio file extensions.
@@ -122,6 +122,8 @@ public final class FileHelper {
         binaryFileExtensions.add("msixbundle");
         binaryFileExtensions.add("flatpak");
         binaryFileExtensions.add("nupkg");
+        binaryFileExtensions.add("sav");
+        binaryFileExtensions.add("fex");
         binaryFileExtensions.addAll(VIDEO_FILE_EXTENSIONS);
         binaryFileExtensions.addAll(AUDIO_FILE_EXTENSIONS);
         binaryFileExtensions.addAll(IMAGE_FILE_EXTENSIONS);

--- a/palladian-core/src/main/java/ws/palladian/extraction/date/WebPageDateEvaluator.java
+++ b/palladian-core/src/main/java/ws/palladian/extraction/date/WebPageDateEvaluator.java
@@ -77,7 +77,7 @@ public final class WebPageDateEvaluator {
         Validate.notNull(type, "type must not be null");
 
         List<RatedDate<ExtractedDate>> dates = getDates(document, type);
-        if (dates.size() > 0) {
+        if (!dates.isEmpty()) {
             return dates.get(0);
         }
         return null;

--- a/palladian-core/src/main/java/ws/palladian/extraction/date/comparators/RatedDateComparator.java
+++ b/palladian-core/src/main/java/ws/palladian/extraction/date/comparators/RatedDateComparator.java
@@ -92,7 +92,7 @@ public class RatedDateComparator implements Comparator<RatedDate<? extends Extra
     private static int compareTechnique(ExtractedDate date1, ExtractedDate date2) {
         int tech1 = getTypeValue(date1);
         int tech2 = getTypeValue(date2);
-        return Integer.valueOf(tech1).compareTo(tech2);
+        return Integer.valueOf(tech2).compareTo(tech1);
     }
 
     private static int getTypeValue(ExtractedDate date) {

--- a/palladian-core/src/test/java/ws/palladian/extraction/ListDiscovererTest.java
+++ b/palladian-core/src/test/java/ws/palladian/extraction/ListDiscovererTest.java
@@ -153,7 +153,7 @@ public class ListDiscovererTest {
         // }
         assertEquals("//table[1]/tbody/tr/td/table/tbody/tr/td/font/a", discoverdEntityXPath);
         assertEquals(81, nodes.size());
-        assertEquals("\nDiszaray", nodes.get(77).getTextContent());
+        assertEquals("Diszaray", nodes.get(77).getTextContent().trim());
 
         document = htmlParser.parse(ResourceHelper.getResourceFile("webPages/pagination13.html"));
         discoverdEntityXPath = ld.discoverEntityXPath(document);

--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/PageAnalyzer.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/PageAnalyzer.java
@@ -389,7 +389,7 @@ public final class PageAnalyzer {
             // TODO allow th to have [] but change getNextSibling then!
             // TODO adding [1] also if no other elements exist could improve performance (XWI)
             String currentNode = node.getNodeName();
-            if ((node.getNextSibling() != null || psCount > 1) && !node.getNodeName().equalsIgnoreCase("html") && !node.getNodeName().equalsIgnoreCase("th")) {
+            if ((node.getNextSibling() != null || psCount > 1) && !node.getNodeName().equalsIgnoreCase("html") && !node.getNodeName().equalsIgnoreCase("th") && !node.getNodeName().equalsIgnoreCase("body")) {
                 currentNode = node.getNodeName() + "[" + psCount + "]";
             }
             // System.out.println(node.getNodeName()+" "+node.getNodeType()+" "+node.getNodeValue());

--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/parser/BaseDocumentParser.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/parser/BaseDocumentParser.java
@@ -58,7 +58,7 @@ public abstract class BaseDocumentParser implements DocumentParser {
      * @param charset The charset.
      * @return <code>true</code> in case the charset is supported, false otherwise.
      */
-    private static boolean isSupportedCharset(String charset) {
+    protected static boolean isSupportedCharset(String charset) {
         if (charset == null) {
             return false;
         }

--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/parser/JsoupParser.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/parser/JsoupParser.java
@@ -2,12 +2,15 @@ package ws.palladian.retrieval.parser;
 
 import org.jsoup.Jsoup;
 import org.jsoup.helper.W3CDom;
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Element;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import ws.palladian.persistence.ParserException;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 /**
  * Parser for HTML documents using Jsoup.
@@ -15,26 +18,103 @@ import java.io.InputStream;
  * @author David Urbansky
  */
 public final class JsoupParser extends BaseDocumentParser {
+
+    private static final Map<String, String> NAMESPACE_MAP = new HashMap<>();
+
+    static {
+        NAMESPACE_MAP.put("xlink", "http://www.w3.org/1999/xlink");
+    }
+
     protected JsoupParser() {
         // instances should be created by the factory.
     }
 
     @Override
     public Document parse(InputSource inputSource) throws ParserException {
-        InputStream r = inputSource.getByteStream();
         try {
-            r.reset();
-            StringBuilder b = new StringBuilder();
-            int c;
-            while ((c = r.read()) > -1) {
-                b.appendCodePoint(c);
-            }
-            r.reset(); // Reset for possible further actions
-            String xml = b.toString();
+            byte[] inputBytes = inputStreamToByteArray(inputSource.getByteStream());
+            String encoding = inputSource.getEncoding();
+            String xml = byteArrayToString(inputBytes, encoding);
             org.jsoup.nodes.Document parse = Jsoup.parse(xml);
+            if (encoding == null) { // make sure content-type meta tag is handled correctly
+                String documentEncoding = getDocumentEncoding(parse);
+                if (documentEncoding != null && !documentEncoding.equalsIgnoreCase(StandardCharsets.UTF_8.name())) {
+                    inputSource.setEncoding(documentEncoding);
+                    xml = byteArrayToString(inputBytes, documentEncoding);
+                    parse = Jsoup.parse(xml);
+                }
+            }
+            // unknown namespaces can cause problems with the documents (e.g. cloning or serializing), this is somehow handled by ValidatorNuParser out of the box
+            addNamespacesToHtml(parse);
             return W3CDom.convert(parse);
         } catch (IOException e) {
             throw new ParserException(e);
+        }
+    }
+
+    private static String getDocumentEncoding(org.jsoup.nodes.Document document) {
+        Element encodingMeta = document.selectFirst("meta[http-equiv=\"content-type\"]");
+        if (encodingMeta == null) {
+            return null;
+        }
+        String content = encodingMeta.attr("content");
+        if (!content.isEmpty()) {
+            String[] parts = content.split(";");
+            for (String part : parts) {
+                if (part.trim().startsWith("charset=")) {
+                    String encoding = part.trim().substring("charset=".length());
+                    if (isSupportedCharset(encoding)) {
+                        return encoding;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String byteArrayToString(byte[] byteArray, String encoding) throws UnsupportedEncodingException {
+        encoding = Optional.ofNullable(encoding).orElse(StandardCharsets.UTF_8.name());
+        return new String(byteArray, encoding);
+    }
+
+    private static byte[] inputStreamToByteArray(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int nRead;
+        byte[] data = new byte[16384];
+        while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, nRead);
+        }
+        buffer.flush();
+        return buffer.toByteArray();
+    }
+
+    private static void addNamespacesToHtml(org.jsoup.nodes.Document document) {
+        Element html = document.selectFirst("html");
+        if (html == null) {
+            return;
+        }
+        Map<String, String> namespaces = new HashMap<>();
+        Set<String> attrs = Collections.synchronizedSet(new HashSet<>());
+        document.getAllElements().parallelStream().forEach(el -> {
+            attrs.add(el.tag().getName());
+            for (Attribute attribute : el.attributes()) {
+                attrs.add(attribute.getKey());
+            }
+        });
+        for (String attr : attrs) {
+            if (!attr.contains(":")) {
+                continue;
+            }
+            String key = attr.split(":")[0];
+            if (key.equals("xmlns") || key.equals("xml")) {
+                continue;
+            }
+            namespaces.put("xmlns:" + key, Optional.ofNullable(NAMESPACE_MAP.get(key)).orElse("http://palladian.ws/2024/" + key));
+        }
+        for (Map.Entry<String, String> entry : namespaces.entrySet()) {
+            if (html.attr(entry.getKey()).isEmpty()) {
+                html.attr(entry.getKey(), entry.getValue());
+            }
         }
     }
 }

--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/parser/JsoupParser.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/parser/JsoupParser.java
@@ -8,7 +8,10 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import ws.palladian.persistence.ParserException;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
@@ -109,7 +112,7 @@ public final class JsoupParser extends BaseDocumentParser {
             if (key.equals("xmlns") || key.equals("xml")) {
                 continue;
             }
-            namespaces.put("xmlns:" + key, Optional.ofNullable(NAMESPACE_MAP.get(key)).orElse("http://palladian.ws/2024/" + key));
+            namespaces.put("xmlns:" + key, Optional.ofNullable(NAMESPACE_MAP.get(key)).orElse("http://www.w3.org/1999/xhtml" + key));
         }
         for (Map.Entry<String, String> entry : namespaces.entrySet()) {
             if (html.attr(entry.getKey()).isEmpty()) {

--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/parser/JsoupParser.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/parser/JsoupParser.java
@@ -6,6 +6,7 @@ import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Element;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
+import ws.palladian.helper.nlp.PatternHelper;
 import ws.palladian.persistence.ParserException;
 
 import java.io.ByteArrayOutputStream;
@@ -14,6 +15,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * Parser for HTML documents using Jsoup.
@@ -23,6 +25,7 @@ import java.util.*;
 public final class JsoupParser extends BaseDocumentParser {
 
     private static final Map<String, String> NAMESPACE_MAP = new HashMap<>();
+    private static final Pattern NAMESPACE_REGEX = PatternHelper.compileOrGet("^[a-zA-Z_][a-zA-Z0-9_.-]*$");
 
     static {
         NAMESPACE_MAP.put("xlink", "http://www.w3.org/1999/xlink");
@@ -110,6 +113,9 @@ public final class JsoupParser extends BaseDocumentParser {
             }
             String key = attr.split(":")[0];
             if (key.equals("xmlns") || key.equals("xml")) {
+                continue;
+            }
+            if (!NAMESPACE_REGEX.matcher(key).matches()) {
                 continue;
             }
             namespaces.put("xmlns:" + key, Optional.ofNullable(NAMESPACE_MAP.get(key)).orElse("http://www.w3.org/1999/xhtml" + key));

--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/parser/ParserFactory.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/parser/ParserFactory.java
@@ -22,11 +22,11 @@ public final class ParserFactory {
      * @return
      */
     public static DocumentParser createHtmlParser() {
-        return new ValidatorNuParser();
+        return new JsoupParser();
     }
 
     public static DocumentParser createHtmlParser2() {
-        return new JsoupParser();
+        return new ValidatorNuParser();
     }
 
     /**


### PR DESCRIPTION
I did a bunch of testing, nevertheless it would be great if you could do some additional testing on your side. The namespace workaround for Jsoup is not the prettiest solution, but I could not find a better one.

(10x parse for each document)
![image](https://github.com/palladian/palladian/assets/9029472/265ea9a3-6b23-4e1e-8312-dd06e57a54dd)
