### PR TITLE
We expect $1 to be parsed to 1 cause used in multiple regex group rep…

### DIFF
--- a/palladian-commons/src/test/java/ws/palladian/helper/math/MathHelperTest.java
+++ b/palladian-commons/src/test/java/ws/palladian/helper/math/MathHelperTest.java
@@ -209,6 +209,7 @@ public class MathHelperTest {
         assertEquals(1.5, MathHelper.parseStringNumber("1½ bla"), 0.001);
         assertEquals(1.5, MathHelper.parseStringNumber("1 ½ bla"), 0.001);
         assertEquals(1777, MathHelper.parseStringNumber("1,777"), 0.001);
+        assertEquals(1, MathHelper.parseStringNumber("$1"), 0.001);
     }
 
     @Test


### PR DESCRIPTION
…lacements like SearchIntentParser

This is only the test case which should be respected 