### PR TITLE
fixed spelling correction for single word terms

### DIFF
--- a/palladian-core/src/main/java/ws/palladian/semantics/PalladianSpellChecker.java
+++ b/palladian-core/src/main/java/ws/palladian/semantics/PalladianSpellChecker.java
@@ -424,6 +424,7 @@ public class PalladianSpellChecker {
         correction.set(false);
         boolean uppercase = false;
         int uppercaseCount = 0;
+        boolean useContext = this.useContext && (leftContext != null || rightContext != null);
         if (!caseSensitive) {
             uppercaseCount = StringHelper.countUppercaseLetters(word);
 


### PR DESCRIPTION
Currently single word terms are not being corrected if the global `useContext` flag is enabled --> so only terms with context are being corrected. This makes sure context validation is only applied if context is actually available.