### PR TITLE
feat(retrieval): pluggable documentValidator on CascadingDocumentRetriever

### DIFF
--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/CascadingDocumentRetriever.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/CascadingDocumentRetriever.java
@@ -15,6 +15,7 @@ import ws.palladian.persistence.json.JsonObject;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 
 /**
@@ -32,6 +33,21 @@ public class CascadingDocumentRetriever extends JsEnabledDocumentRetriever {
      */
     private List<String> badDocumentIndicatorTexts;
     private List<String> goodDocumentIndicatorTexts;
+
+    /**
+     * Optional structural acceptance check, consulted for every stage result in addition to the
+     * good/bad indicator texts. Receives the originally REQUESTED url and the fetched document;
+     * returning {@code false} rejects the document and makes the cascade escalate to the next
+     * stage. {@code null} (the default) keeps the current behavior.
+     *
+     * <p>Motivation: a page can be textually unsuspicious yet wrong for the request. E.g. some
+     * shops 301-redirect deep product URLs to their home page for datacenter IPs — the home page
+     * is a valid, &gt;500-char page matching no bad indicator, so the cascade would accept it at
+     * the first (cheap, datacenter) stage and never escalate to the cloud retrievers whose
+     * residential IPs would fetch the real page. A validator comparing the requested url with
+     * {@code document.getDocumentURI()} catches exactly that.</p>
+     */
+    private BiPredicate<String, Document> documentValidator;
 
     /**
      * Keep track of failing requests.
@@ -182,6 +198,15 @@ public class CascadingDocumentRetriever extends JsEnabledDocumentRetriever {
             this.badDocumentIndicatorTexts = new ArrayList<>();
         }
         badDocumentIndicatorTexts.add(badDocumentIndicatorText);
+    }
+
+    public BiPredicate<String, Document> getDocumentValidator() {
+        return documentValidator;
+    }
+
+    /** See {@link #documentValidator}: {@code (requestedUrl, document) -> accept?}; rejecting escalates to the next stage. */
+    public void setDocumentValidator(BiPredicate<String, Document> documentValidator) {
+        this.documentValidator = documentValidator;
     }
 
     public List<String> getGoodDocumentIndicatorTexts() {
@@ -340,7 +365,7 @@ public class CascadingDocumentRetriever extends JsEnabledDocumentRetriever {
                 LOGGER.error(e.getMessage(), e);
             }
 
-            goodDocument = isGoodDocument(document);
+            goodDocument = isGoodDocument(url, document);
 
             if (goodDocument && retrieverDocumentCallback != null) {
                 retrieverDocumentCallback.accept(Pair.of(documentRetriever, document));
@@ -399,7 +424,7 @@ public class CascadingDocumentRetriever extends JsEnabledDocumentRetriever {
                 configure(cloudDocumentRetriever);
                 StopWatch stopWatch1 = new StopWatch();
                 document = cloudDocumentRetriever.getWebDocument(url);
-                goodDocument = isGoodDocument(document);
+                goodDocument = isGoodDocument(url, document);
 
                 if (goodDocument && retrieverDocumentCallback != null) {
                     retrieverDocumentCallback.accept(Pair.of(cloudDocumentRetriever, document));
@@ -481,7 +506,7 @@ public class CascadingDocumentRetriever extends JsEnabledDocumentRetriever {
                     throw new RuntimeException("Render watchdog timeout after " + getTimeoutSeconds() + "s for " + url, te);
                 }
 
-                result.goodDocument = isGoodDocument(result.document);
+                result.goodDocument = isGoodDocument(url, result.document);
 
                 // Auto-solving challenge (Akamai etc.) — wait on live driver and re-read.
                 if (!result.goodDocument && isAutoSolvingChallenge(result.document)) {
@@ -493,7 +518,7 @@ public class CascadingDocumentRetriever extends JsEnabledDocumentRetriever {
                     } catch (Exception e) {
                         LOGGER.debug("Could not re-read document after challenge wait", e);
                     }
-                    result.goodDocument = isGoodDocument(result.document);
+                    result.goodDocument = isGoodDocument(url, result.document);
                     resolvingExplanation.add(
                             "auto-solving challenge " + (resolved && result.goodDocument ? "resolved" : "unresolved") + " after " + waitStopWatch.getElapsedTimeString());
                     LOGGER.info("Auto-solving challenge wait for {} ({}) — resolved: {}, goodDocument: {}, time: {}", url, label, resolved, result.goodDocument,
@@ -678,12 +703,18 @@ public class CascadingDocumentRetriever extends JsEnabledDocumentRetriever {
         this.autoSolvingChallengeWaitSeconds = autoSolvingChallengeWaitSeconds;
     }
 
-    private boolean isGoodDocument(Document document) {
+    private boolean isGoodDocument(String requestedUrl, Document document) {
         if (document == null) {
             return false;
         }
         HttpResult httpResult = (HttpResult) document.getUserData("httpResult");
         if (httpResult != null && httpResult.getStatusCode() == 403) {
+            return false;
+        }
+        // structural check before the textual ones: a document can be textually unsuspicious
+        // (or even contain a good indicator) yet be the wrong page for the request — e.g. an
+        // anti-bot redirect onto the home page. Good indicator texts must not rescue such a page.
+        if (documentValidator != null && !documentValidator.test(requestedUrl, document)) {
             return false;
         }
         String s = HtmlHelper.getInnerXml(document);

--- a/palladian-retrieval/src/main/java/ws/palladian/retrieval/CascadingDocumentRetriever.java
+++ b/palladian-retrieval/src/main/java/ws/palladian/retrieval/CascadingDocumentRetriever.java
@@ -714,8 +714,15 @@ public class CascadingDocumentRetriever extends JsEnabledDocumentRetriever {
         // structural check before the textual ones: a document can be textually unsuspicious
         // (or even contain a good indicator) yet be the wrong page for the request — e.g. an
         // anti-bot redirect onto the home page. Good indicator texts must not rescue such a page.
-        if (documentValidator != null && !documentValidator.test(requestedUrl, document)) {
-            return false;
+        if (documentValidator != null) {
+            try {
+                if (!documentValidator.test(requestedUrl, document)) {
+                    return false;
+                }
+            } catch (RuntimeException e) {
+                LOGGER.warn("Document validator threw an exception for requestedUrl={} (documentURI={}); rejecting document", requestedUrl, document.getDocumentURI(), e);
+                return false;
+            }
         }
         String s = HtmlHelper.getInnerXml(document);
         if (!getGoodDocumentIndicatorTexts().isEmpty()) {

--- a/palladian-retrieval/src/test/java/ws/palladian/retrieval/CascadingDocumentRetrieverValidatorTest.java
+++ b/palladian-retrieval/src/test/java/ws/palladian/retrieval/CascadingDocumentRetrieverValidatorTest.java
@@ -1,0 +1,170 @@
+package ws.palladian.retrieval;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies the {@code documentValidator} hook on {@link CascadingDocumentRetriever}: a stage result the
+ * validator rejects must not be accepted, so the cascade escalates to the next stage — even when the
+ * rejected page is otherwise unsuspicious (&gt;500 chars, no bad indicator, or even a good indicator).
+ *
+ * <p>Motivating case: a shop 301-redirects a deep product URL to its home page for datacenter IPs.
+ * The home page is a "good-looking" document, so without the validator the cascade accepts it at the
+ * first (cheap, datacenter) stage and never reaches the cloud retrievers whose residential IPs would
+ * fetch the real page.</p>
+ *
+ * <p>Offline: the cascade is built with {@code null} local retriever/pools and stubbed cloud stages.</p>
+ */
+public class CascadingDocumentRetrieverValidatorTest {
+
+    private static final String PRODUCT_URL = "https://shop.example/product/widget-123.html";
+    private static final String ROOT_URL = "https://shop.example/";
+
+    /** A cloud retriever stub returning a fixed document, recording every requested URL. */
+    private static final class StubStage extends JsEnabledDocumentRetriever {
+        final List<String> requestedUrls = new ArrayList<>();
+        private final Document result;
+
+        StubStage(Document result) {
+            this.result = result;
+        }
+
+        @Override
+        public Document getWebDocument(String url) {
+            requestedUrls.add(url);
+            return result;
+        }
+
+        @Override
+        public int requestsLeft() {
+            return Integer.MAX_VALUE;
+        }
+    }
+
+    /** A &gt;500-char document (passes the length heuristic) whose URI is the FINAL url of the fetch. */
+    private static Document doc(String finalUri) throws Exception {
+        Document d = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element html = d.createElement("html");
+        Element body = d.createElement("body");
+        StringBuilder text = new StringBuilder("Welcome to our shop. ");
+        while (text.length() < 600) {
+            text.append("Lots of perfectly normal storefront text. ");
+        }
+        body.setTextContent(text.toString());
+        html.appendChild(body);
+        d.appendChild(html);
+        d.setDocumentURI(finalUri);
+        return d;
+    }
+
+    private static CascadingDocumentRetriever cascadeWith(JsEnabledDocumentRetriever... stages) {
+        // casts disambiguate the (DocumentRetriever, pool, pool, JsEnabledDocumentRetriever...) constructor
+        return new CascadingDocumentRetriever((DocumentRetriever) null, (RenderingDocumentRetrieverPool) null, (RenderingDocumentRetrieverPool) null, stages);
+    }
+
+    /** Rejects a fetch that asked for a deep path but settled on the site root (anti-bot home bounce). */
+    private static boolean notBouncedToRoot(String requestedUrl, Document document) {
+        return !ROOT_URL.equals(document.getDocumentURI());
+    }
+
+    @Test
+    public void withoutValidatorTheBouncedPageIsAccepted() throws Exception {
+        // documents the status quo the validator exists to fix
+        StubStage bouncing = new StubStage(doc(ROOT_URL));
+        StubStage residential = new StubStage(doc(PRODUCT_URL));
+        CascadingDocumentRetriever cascade = cascadeWith(bouncing, residential);
+        try {
+            Document result = cascade.getWebDocument(PRODUCT_URL);
+
+            assertEquals(ROOT_URL, result.getDocumentURI());
+            assertTrue("without a validator the first stage's bounce is accepted", residential.requestedUrls.isEmpty());
+        } finally {
+            cascade.close();
+        }
+    }
+
+    @Test
+    public void validatorRejectionEscalatesToTheNextStage() throws Exception {
+        StubStage bouncing = new StubStage(doc(ROOT_URL));
+        StubStage residential = new StubStage(doc(PRODUCT_URL));
+        CascadingDocumentRetriever cascade = cascadeWith(bouncing, residential);
+        try {
+            cascade.setDocumentValidator(CascadingDocumentRetrieverValidatorTest::notBouncedToRoot);
+
+            Document result = cascade.getWebDocument(PRODUCT_URL);
+
+            assertEquals(1, bouncing.requestedUrls.size());
+            assertEquals("rejected first stage must escalate to the second", 1, residential.requestedUrls.size());
+            assertEquals(PRODUCT_URL, result.getDocumentURI());
+        } finally {
+            cascade.close();
+        }
+    }
+
+    @Test
+    public void validatorAcceptedDocumentStopsTheCascade() throws Exception {
+        Document good = doc(PRODUCT_URL);
+        StubStage first = new StubStage(good);
+        StubStage second = new StubStage(doc(PRODUCT_URL));
+        CascadingDocumentRetriever cascade = cascadeWith(first, second);
+        try {
+            cascade.setDocumentValidator(CascadingDocumentRetrieverValidatorTest::notBouncedToRoot);
+
+            Document result = cascade.getWebDocument(PRODUCT_URL);
+
+            assertSame(good, result);
+            assertTrue("an accepted document must not escalate further", second.requestedUrls.isEmpty());
+        } finally {
+            cascade.close();
+        }
+    }
+
+    @Test
+    public void validatorOverrulesGoodDocumentIndicatorTexts() throws Exception {
+        // A structural rejection must not be rescued by a textual good indicator: the bounced home
+        // page may well contain marketing text that matches a good indicator.
+        StubStage bouncing = new StubStage(doc(ROOT_URL));
+        StubStage residential = new StubStage(doc(PRODUCT_URL));
+        CascadingDocumentRetriever cascade = cascadeWith(bouncing, residential);
+        try {
+            cascade.addGoodDocumentIndicatorText("Welcome to our shop");
+            cascade.setDocumentValidator(CascadingDocumentRetrieverValidatorTest::notBouncedToRoot);
+
+            Document result = cascade.getWebDocument(PRODUCT_URL);
+
+            assertEquals(PRODUCT_URL, result.getDocumentURI());
+            assertEquals(1, residential.requestedUrls.size());
+        } finally {
+            cascade.close();
+        }
+    }
+
+    @Test
+    public void whenEveryStageIsRejectedTheLastDocumentIsReturned() throws Exception {
+        // existing cascade contract: exhausted stages return the last (bad) document, not null —
+        // callers relying on that (e.g. cache-no-block guards) keep working with a validator set
+        StubStage bounce1 = new StubStage(doc(ROOT_URL));
+        StubStage bounce2 = new StubStage(doc(ROOT_URL));
+        CascadingDocumentRetriever cascade = cascadeWith(bounce1, bounce2);
+        try {
+            cascade.setDocumentValidator(CascadingDocumentRetrieverValidatorTest::notBouncedToRoot);
+
+            Document result = cascade.getWebDocument(PRODUCT_URL);
+
+            assertEquals(1, bounce1.requestedUrls.size());
+            assertEquals(1, bounce2.requestedUrls.size());
+            assertEquals(ROOT_URL, result.getDocumentURI());
+        } finally {
+            cascade.close();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A stage result can be textually unsuspicious yet **wrong for the request**. Concrete case: some shops (e.g. mindfactory.de) 301-redirect deep product URLs to their **home page** when the request comes from a datacenter IP. The home page is a valid 200, >500-char page matching no bad-document indicator — so the cascade accepts it at the first (cheap, datacenter) stage and never escalates to the cloud retrievers whose **residential IPs would fetch the real page**.

There is currently no lever for this: good-document indicators only early-*accept* (their absence does not reject), and the per-call `List<String>` is the `resolvingExplanation` log accumulator.

## Solution

`setDocumentValidator(BiPredicate<String, Document>)` — an optional structural acceptance check, consulted in `isGoodDocument` for every stage result:

- receives the originally **requested url** and the fetched document; returning `false` rejects the result and the cascade escalates exactly as it does for bad documents today
- checked **before** the good-indicator early-accept: a bounced home page must not be rescued by marketing text that happens to match a good indicator
- `null` (default) keeps current behavior; when every stage is rejected the cascade still returns the last document (existing contract, covered by a test)

Callers can e.g. compare the requested url with `document.getDocumentURI()` to detect redirect-to-home bot walls:

```java
cascade.setDocumentValidator((requestedUrl, doc) ->
        !bouncedToSiteRoot(requestedUrl, doc.getDocumentURI()));
```

## Tests

`CascadingDocumentRetrieverValidatorTest` — 5 offline tests (stubbed stages, same pattern as `CascadingDocumentRetrieverBlacklistTest`): status quo without validator, rejection escalates to the next stage, acceptance stops the cascade, validator overrules good-indicator texts, all-rejected returns the last document. Existing `CascadingDocumentRetrieverBlacklistTest` / `WebDocumentRetrieverBlacklistTest` unchanged and green.